### PR TITLE
Deduct resources, then add hero

### DIFF
--- a/src/app/helpers/recruit.ts
+++ b/src/app/helpers/recruit.ts
@@ -40,8 +40,8 @@ export function recruitHero(hero: GameHero): void {
     return;
   }
 
-  addHero(hero);
   loseResource(resource, recruitCost());
+  addHero(hero);
 }
 
 export function doReroll(): void {


### PR DESCRIPTION
# Description

When recruiting a hero, it was adding the hero first then deducting the cost. The issue this creates is when calculating the cost of heros, it checks the total amount of heros owned, so because it was adding the hero first it was charging you as though you had one more hero than you have.

Fixes #74 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
